### PR TITLE
hostfile deprecated

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -8,7 +8,7 @@
 
 # location of inventory file, eliminates need to specify -i
 
-hostfile = ./production
+inventory = ./production
 
 # location of ansible library, eliminates need to specify --module-path
 


### PR DESCRIPTION
According to https://docs.ansible.com/ansible/2.3/intro_configuration.html#hostfile

hostfile is a deprecated setting since 1.9 and suggests to use inventory instead for newer versions.