### PR TITLE
Improved apt-upgrade-update.yml

### DIFF
--- a/playbooks/apt-upgrade-update.yml
+++ b/playbooks/apt-upgrade-update.yml
@@ -1,6 +1,12 @@
 ---
 - hosts: all
-  sudo: yes
+  become: yes
   tasks:
-    - shell: apt-get upgrade -y; apt-get update
-  
+    - name: Update apt cache
+      apt:
+        update_cache: yes
+      changed_when: false
+
+    - name: Upgrade all packages
+      apt:
+        upgrade: 'yes'


### PR DESCRIPTION
1. The sudo directive is deprecated since Ansible 2.9, and it's recommended to use become instead.
2. Also, it's a good practice to use Ansible's apt module instead of the shell command for apt operations.